### PR TITLE
trying something different to get the branch name

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,9 +21,10 @@ jobs:
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    - name: Get base branch name
+    - name: Get Branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: branch-name
-      uses: tj-actions/branch-names@v6
 
     - name: Build
       run: |
@@ -33,4 +34,4 @@ jobs:
     - name: Publish Dry Run
       run: |
         echo "yarn version --minor"
-        echo "yarn publish --access public --tag ${{ steps.branch-name.outputs.base_ref_branch }}"
+        echo "yarn publish --access public --tag ${{ steps.branch-name.outputs.branch }}"

--- a/src/isJSON.test.ts
+++ b/src/isJSON.test.ts
@@ -1,0 +1,11 @@
+import { isJson } from "./isJSON";
+
+describe("isJson function", () => {
+  test("can parse JSON", () => {
+    const json = `{
+      "foo": "bar"
+    }`;
+
+    expect(isJson(json)).toBe(true);
+  });
+});


### PR DESCRIPTION
I need the branch name for the dist tag
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.13.19e2672.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nathanstilwell/functions@0.3.1--canary.13.19e2672.0
  # or 
  yarn add @nathanstilwell/functions@0.3.1--canary.13.19e2672.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
